### PR TITLE
feat: polish dark theme across the UI

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-gradient-to-b from-orange-50 to-white ">
+  <div class="bg-gradient-to-b from-orange-50 to-white dark:from-slate-950 dark:to-slate-900 text-slate-900 dark:text-slate-100">
     <NuxtPage />
   </div>
 </template>

--- a/app/components/cart/Drawer.vue
+++ b/app/components/cart/Drawer.vue
@@ -1,30 +1,30 @@
 <template>
   <aside id="cartDrawer" class="hidden md:block sticky top-[120px] h-fit">
-    <div class="bg-white rounded-2xl border border-slate-100 shadow-soft p-4">
-      <h3 class="text-lg font-semibold">Ваш заказ</h3>
+    <div class="bg-white rounded-2xl border border-slate-100 shadow-soft p-4 dark:bg-slate-950 dark:border-slate-800">
+      <h3 class="text-lg font-semibold text-slate-900 dark:text-slate-100">Ваш заказ</h3>
       <div class="mt-3 flex flex-col gap-3">
-        <div v-if="!groupedCart.length" class="text-slate-500 text-sm">Корзина пуста</div>
+        <div v-if="!groupedCart.length" class="text-slate-500 text-sm dark:text-slate-400">Корзина пуста</div>
         <div v-else>
           <div
             v-for="entry in groupedCart"
             :key="entry.key"
-            class="flex items-start justify-between gap-2"
+            class="flex items-start justify-between gap-2 text-slate-700 dark:text-slate-200"
           >
             <div>
-              <div class="font-medium">{{ entry.item.name }}</div>
-              <div v-if="cartEntryDescription(entry)" class="text-[12px] text-slate-500">
+              <div class="font-medium text-slate-900 dark:text-slate-100">{{ entry.item.name }}</div>
+              <div v-if="cartEntryDescription(entry)" class="text-[12px] text-slate-500 dark:text-slate-400">
                 {{ cartEntryDescription(entry) }}
               </div>
-              <div class="text-[12px] text-slate-500">
+              <div class="text-[12px] text-slate-500 dark:text-slate-400">
                 {{ fmt(entry.item.price) }} × {{ entry.quantity }}
               </div>
             </div>
-            <div class="text-right">
+            <div class="text-right text-slate-900 dark:text-slate-100">
               <div class="font-semibold">{{ fmt(entry.lineTotal) }}</div>
               <div class="mt-1 flex items-center gap-1 justify-end">
-                <button class="w-6 h-6 rounded-full border" @click="decrement(entry.key)">-</button>
-                <button class="w-6 h-6 rounded-full border" @click="increment(entry.item)">+</button>
-                <button class="ml-1 text-slate-400 hover:text-red-500" @click="remove(entry.key)">
+                <button class="w-6 h-6 rounded-full border border-slate-200 hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800" @click="decrement(entry.key)">-</button>
+                <button class="w-6 h-6 rounded-full border border-slate-200 hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800" @click="increment(entry.item)">+</button>
+                <button class="ml-1 text-slate-400 hover:text-red-500 dark:text-slate-500 dark:hover:text-red-400" @click="remove(entry.key)">
                   Удалить
                 </button>
               </div>
@@ -32,15 +32,15 @@
           </div>
         </div>
       </div>
-      <div class="mt-4 border-t pt-3 text-sm text-slate-600 space-y-1">
+      <div class="mt-4 border-t pt-3 text-sm text-slate-600 space-y-1 dark:border-slate-800 dark:text-slate-300">
         <div class="flex justify-between"><span>Доставка</span><span id="deliveryFee">{{ deliveryText }}</span></div>
-        <div class="flex justify-between font-semibold text-slate-800">
+        <div class="flex justify-between font-semibold text-slate-800 dark:text-slate-100">
           <span>Итого</span>
           <span id="cartTotal">{{ fmt(totals.total) }}</span>
         </div>
         <div
           id="minOrderNote"
-          class="text-[12px] text-amber-700 bg-amber-50 rounded-lg p-2"
+          class="text-[12px] text-amber-700 bg-amber-50 rounded-lg p-2 dark:text-amber-300 dark:bg-amber-900/40"
           :class="{ hidden: meetsMinOrder }"
         >
           Минимальная сумма заказа: {{ fmt(minOrder) }}
@@ -58,7 +58,7 @@
         id="waOrder"
         :href="whatsappUrl"
         target="_blank"
-        class="mt-2 w-full inline-block text-center rounded-xl border border-green-600 text-green-700 py-2 hover:bg-green-50"
+        class="mt-2 w-full inline-block text-center rounded-xl border border-green-600 text-green-700 py-2 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/40"
         :class="{ 'pointer-events-none opacity-60': !groupedCart.length }"
       >
         WhatsApp

--- a/app/components/cart/QuickOrder.vue
+++ b/app/components/cart/QuickOrder.vue
@@ -5,30 +5,30 @@
     :class="{ hidden: !isOpen || !hasItems, flex: isOpen && hasItems }"
   >
     <div class="absolute inset-0 bg-black/50" @click="close"></div>
-    <div class="w-full md:w-[720px] bg-white rounded-t-2xl md:rounded-2xl p-5 max-h-[90vh] overflow-y-auto shadow-soft z-50">
+    <div class="w-full md:w-[720px] bg-white rounded-t-2xl md:rounded-2xl p-5 max-h-[90vh] overflow-y-auto shadow-soft z-50 dark:bg-slate-950 dark:text-slate-100">
       <div class="flex items-start justify-between gap-4">
-        <h3 class="text-xl font-semibold">Оформление заказа</h3>
-        <button class="text-slate-500" @click="close">✕</button>
+        <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100">Оформление заказа</h3>
+        <button class="text-slate-500 dark:text-slate-400" @click="close">✕</button>
       </div>
       <form class="mt-4 grid md:grid-cols-2 gap-4" @submit.prevent="handleSubmit">
         <div class="grid gap-3">
-          <label class="text-sm">Имя
-            <input v-model="form.name" name="name" required class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2" placeholder="Ваше имя"/>
+          <label class="text-sm text-slate-700 dark:text-slate-200">Имя
+            <input v-model="form.name" name="name" required class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-400" placeholder="Ваше имя"/>
           </label>
-          <label class="text-sm">Телефон
-            <input v-model="form.phone" name="phone" required class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2" placeholder="+996..."/>
+          <label class="text-sm text-slate-700 dark:text-slate-200">Телефон
+            <input v-model="form.phone" name="phone" required class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-400" placeholder="+996..."/>
           </label>
-          <label class="text-sm">Способ получения
-            <select v-model="form.type" name="type" class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2">
+          <label class="text-sm text-slate-700 dark:text-slate-200">Способ получения
+            <select v-model="form.type" name="type" class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100">
               <option value="delivery">Доставка</option>
               <option value="pickup">Самовывоз</option>
             </select>
           </label>
-          <label class="text-sm" v-show="requiresAddress">Адрес (для доставки)
-            <input v-model="form.address" name="address" class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2" placeholder="Улица, дом, подъезд"/>
+          <label class="text-sm text-slate-700 dark:text-slate-200" v-show="requiresAddress">Адрес (для доставки)
+            <input v-model="form.address" name="address" class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-400" placeholder="Улица, дом, подъезд"/>
           </label>
-          <label class="text-sm">Время
-            <select v-model="form.time" name="time" class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2">
+          <label class="text-sm text-slate-700 dark:text-slate-200">Время
+            <select v-model="form.time" name="time" class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100">
               <option value="asap">Как можно скорее</option>
               <option value="30m">Через 30 минут</option>
               <option value="1h">Через 1 час</option>
@@ -36,12 +36,12 @@
           </label>
         </div>
         <div class="grid gap-3">
-          <div class="p-3 rounded-xl bg-slate-50 text-sm">
-            <div class="font-medium">Состав заказа</div>
-            <div class="mt-1 whitespace-pre-wrap">{{ orderSummary }}</div>
+          <div class="p-3 rounded-xl bg-slate-50 text-sm dark:bg-slate-900/80">
+            <div class="font-medium text-slate-800 dark:text-slate-100">Состав заказа</div>
+            <div class="mt-1 whitespace-pre-wrap text-slate-700 dark:text-slate-200">{{ orderSummary }}</div>
           </div>
-          <label class="text-sm">Комментарий курьеру
-            <textarea v-model="form.comment" name="comment" rows="4" class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2" placeholder="Код домофона, пожелания…"></textarea>
+          <label class="text-sm text-slate-700 dark:text-slate-200">Комментарий курьеру
+            <textarea v-model="form.comment" name="comment" rows="4" class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-400" placeholder="Код домофона, пожелания…"></textarea>
           </label>
           <button class="rounded-xl bg-brand-600 text-white py-2.5 hover:bg-brand-700 disabled:opacity-50" :disabled="!hasItems">
             Подтвердить заказ
@@ -49,7 +49,7 @@
           <a
             :href="whatsappOrderLink"
             target="_blank"
-            class="rounded-xl border border-green-600 text-green-700 py-2 text-center hover:bg-green-50"
+            class="rounded-xl border border-green-600 text-green-700 py-2 text-center hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/40"
             :class="{ 'pointer-events-none opacity-60': !hasItems }"
           >
             Отправить в WhatsApp

--- a/app/components/dialog/options.vue
+++ b/app/components/dialog/options.vue
@@ -1,19 +1,19 @@
 <template>
   <div v-if="isVisible" class="fixed inset-0 z-50 flex items-center justify-center">
     <div class="absolute inset-0 bg-black/50" @click="close"></div>
-    <div class="relative bg-white w-[92vw] max-w-md rounded-2xl p-5 shadow-soft">
+    <div class="relative bg-white w-[92vw] max-w-md rounded-2xl p-5 shadow-soft dark:bg-slate-950 dark:text-slate-100">
       <div class="flex items-start justify-between">
-        <div class="font-semibold text-lg">{{ item.name }}</div>
-        <button class="text-slate-500" @click="close">✕</button>
+        <div class="font-semibold text-lg text-slate-900 dark:text-slate-100">{{ item.name }}</div>
+        <button class="text-slate-500 dark:text-slate-400" @click="close">✕</button>
       </div>
-      
-      <div class="space-y-2 mt-4">
+
+      <div class="space-y-2 mt-4 text-slate-700 dark:text-slate-200">
         <!-- Size selection -->
         <label v-if="item.options?.sizes?.length" class="text-sm block">
           Размер
           <select 
             v-model="selectedSizeIndex" 
-            class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2"
+            class="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100"
           >
             <option 
               v-for="(size, index) in item.options.sizes" 
@@ -29,10 +29,10 @@
         <div v-if="item.options?.extras?.length" class="text-sm">
           Добавки
           <div class="mt-1 grid grid-cols-2 gap-2">
-            <label 
-              v-for="(extra, index) in item.options.extras" 
+            <label
+              v-for="(extra, index) in item.options.extras"
               :key="index"
-              class="flex gap-2 items-center text-sm border rounded-xl px-3 py-2"
+              class="flex gap-2 items-center text-sm border rounded-xl px-3 py-2 dark:border-slate-700 dark:bg-slate-900/60"
             >
               <input 
                 type="checkbox" 
@@ -54,7 +54,7 @@
           Добавить
         </button>
         <button 
-          class="px-4 py-2 rounded-xl border" 
+          class="px-4 py-2 rounded-xl border border-slate-200 text-slate-700 dark:border-slate-700 dark:text-slate-200"
           @click="close"
         >
           Отмена

--- a/app/components/home/Content.vue
+++ b/app/components/home/Content.vue
@@ -1,11 +1,11 @@
 <template>
   <!-- Header / Hero -->
-  <header id="hero" class="bg-white">
+  <header id="hero" class="bg-white dark:bg-slate-950">
     <div class="mx-auto container-capped px-4 pt-8 pb-10">
       <div class="grid md:grid-cols-2 gap-6 items-center">
         <div>
-          <h1 id="cafeName" class="text-3xl md:text-4xl font-extrabold leading-tight">{{ settings.cafeName }}</h1>
-          <p id="announcement" class="mt-3 text-slate-600">{{ settings.announcement }}</p>
+          <h1 id="cafeName" class="text-3xl md:text-4xl font-extrabold leading-tight text-slate-900 dark:text-slate-100">{{ settings.cafeName }}</h1>
+          <p id="announcement" class="mt-3 text-slate-600 dark:text-slate-300">{{ settings.announcement }}</p>
           <!-- <div class="mt-5 flex gap-3">
             <a href="#controls" class="px-5 py-2.5 rounded-xl bg-brand-600 text-white hover:bg-brand-700 shadow-soft">Смотреть меню</a>
           </div> -->
@@ -30,7 +30,7 @@
   </header>
 
   <!-- Controls: Search + Categories -->
-  <section id="controls" class="sticky top-[46px] z-30 bg-white/70 backdrop-blur border-b border-slate-100">
+  <section id="controls" class="sticky top-[46px] z-30 bg-white/70 backdrop-blur border-b border-slate-100 dark:bg-slate-950/80 dark:border-slate-800">
     <div class="mx-auto container-capped px-4 py-3 flex flex-col md:flex-row gap-3 md:items-center md:justify-between">
       <div class="flex items-center gap-2 w-full md:w-1/2">
         <input
@@ -38,16 +38,16 @@
           v-model="searchTerm"
           type="search"
           placeholder="Поиск по меню…"
-          class="w-full rounded-xl border border-slate-200 px-4 py-2.5 outline-none focus:ring-2 focus:ring-brand-300"
+          class="w-full rounded-xl border border-slate-200 px-4 py-2.5 outline-none focus:ring-2 focus:ring-brand-300 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-100 dark:placeholder-slate-400 dark:focus:ring-brand-500"
         />
       </div>
       <div id="categories" class="flex gap-2 overflow-x-auto">
         <button
           v-for="category in categories"
           :key="category"
-          class="px-3 py-1.5 rounded-full text-sm border border-slate-200 hover:bg-slate-50 whitespace-nowrap"
+          class="px-3 py-1.5 rounded-full text-sm border border-slate-200 hover:bg-slate-50 whitespace-nowrap dark:text-slate-300 dark:border-slate-700 dark:hover:bg-slate-800"
           :class="{
-            'bg-brand-600 text-white border-brand-600': selectedCategory === category,
+            'bg-brand-600 text-white border-brand-600 dark:border-brand-500': selectedCategory === category,
           }"
           @click="selectCategory(category)"
         >
@@ -66,13 +66,13 @@
     />
 
     <!-- Cart Drawer (sticky on desktop) -->
-  <CartDrawer
-    :delivery-fee="settings.deliveryFee"
-    :min-order="settings.minOrder"
-    :whatsapp-phone="settings.whatsapp"
-    :cafe-name="settings.cafeName"
-    @checkout="openQuickOrder"
-  />
+    <CartDrawer
+      :delivery-fee="settings.deliveryFee"
+      :min-order="settings.minOrder"
+      :whatsapp-phone="settings.whatsapp"
+      :cafe-name="settings.cafeName"
+      @checkout="openQuickOrder"
+    />
   </main>
 
   <CartQuickOrder
@@ -86,10 +86,10 @@
 
   <!-- Mobile Cart Bar -->
   <div class="md:hidden fixed bottom-4 inset-x-0 z-40 px-4">
-    <div class="bg-white border border-slate-200 shadow-soft rounded-2xl px-4 py-2 flex items-center justify-between">
+    <div class="bg-white border border-slate-200 shadow-soft rounded-2xl px-4 py-2 flex items-center justify-between dark:bg-slate-950 dark:border-slate-800">
       <div>
-        <div class="text-xs text-slate-500">Итого</div>
-        <div id="cartTotalMobile" class="font-semibold">{{ fmt(totals.total) }}</div>
+        <div class="text-xs text-slate-500 dark:text-slate-400">Итого</div>
+        <div id="cartTotalMobile" class="font-semibold text-slate-900 dark:text-slate-100">{{ fmt(totals.total) }}</div>
       </div>
       <button
         class="rounded-xl bg-brand-600 text-white px-4 py-2 disabled:opacity-50"

--- a/app/components/layout/AppFooter.vue
+++ b/app/components/layout/AppFooter.vue
@@ -1,13 +1,13 @@
 <template>
-  <footer id="footer" class="mt-8 bg-white border-t">
-    <div class="mx-auto container-capped px-4 pt-6 pb-[96px] md:pb-6 text-sm text-slate-600 flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-between">
+  <footer id="footer" class="mt-8 bg-white border-t dark:bg-slate-950 dark:border-slate-800">
+    <div class="mx-auto container-capped px-4 pt-6 pb-[96px] md:pb-6 text-sm text-slate-600 dark:text-slate-300 flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-between">
       <div>
         <strong id="fCafe">{{ settings.cafeName }}</strong> • <span id="fAddr">{{ settings.address }}</span> •
         <a id="fCall" class="underline" :href="callHref">{{ settings.phone }}</a>
       </div>
       <div class="flex gap-2">
-        <button @click="printPage" class="px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200">🖨️ Печать QR/меню</button>
-        <button id="darkToggleBottom" class="px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200" @click="toggleTheme">🌗 Тёмная тема</button>
+        <button @click="printPage" class="px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700">🖨️ Печать QR/меню</button>
+        <button id="darkToggleBottom" class="px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700" @click="toggleTheme">🌗 Тёмная тема</button>
       </div>
     </div>
   </footer>

--- a/app/components/layout/AppHeader.vue
+++ b/app/components/layout/AppHeader.vue
@@ -1,17 +1,17 @@
 <template>
-  <div id="topbar" class="w-full bg-white/70 backdrop-blur sticky top-0 z-40 shadow-soft">
-    <div class="mx-auto container-capped px-4 py-2 flex items-center justify-between gap-2">
+  <div id="topbar" class="w-full bg-white/70 dark:bg-slate-950/70 backdrop-blur sticky top-0 z-40 shadow-soft">
+    <div class="mx-auto container-capped px-4 py-2 flex items-center justify-between gap-2 text-slate-700 dark:text-slate-200">
       <div class="flex items-center gap-3">
-        <button id="themeToggle" class="px-3 py-1 rounded-full text-sm border border-slate-200 hover:bg-slate-50" @click="toggleTheme">
+        <button id="themeToggle" class="px-3 py-1 rounded-full text-sm border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800" @click="toggleTheme">
           🌓 Тема
         </button>
-        <span class="hidden sm:inline text-sm text-slate-600">⏰ <span id="openHours">{{ settings.openHours }}</span></span>
-        <span class="hidden md:inline text-sm text-slate-600">📍 <span id="address">{{ settings.address }}</span></span>
+        <span class="hidden sm:inline text-sm text-slate-600 dark:text-slate-300">⏰ <span id="openHours">{{ settings.openHours }}</span></span>
+        <span class="hidden md:inline text-sm text-slate-600 dark:text-slate-300">📍 <span id="address">{{ settings.address }}</span></span>
       </div>
       <div class="flex items-center gap-2">
         <a
           id="callLink"
-          class="text-sm px-3 py-1 rounded-full border border-brand-300 text-brand-700 hover:bg-brand-50"
+          class="text-sm px-3 py-1 rounded-full border border-brand-300 text-brand-700 hover:bg-brand-50 dark:border-brand-500 dark:text-brand-200 dark:hover:bg-brand-900/40"
           :href="callHref"
         >
           ☎ Позвонить
@@ -25,7 +25,7 @@
           Корзина
           <span
             id="cartCount"
-            class="min-w-4 min-h-[20px] flex items-center justify-center leading-[normal] absolute -top-2 -right-2 text-[11px] bg-white text-brand-700 border border-brand-600 rounded-full px-1.5"
+            class="min-w-4 min-h-[20px] flex items-center justify-center leading-[normal] absolute -top-2 -right-2 text-[11px] bg-white text-brand-700 border border-brand-600 rounded-full px-1.5 dark:bg-slate-950 dark:text-brand-200 dark:border-brand-500"
           >
             {{ cartCount }}
           </span>

--- a/app/components/menu/card.vue
+++ b/app/components/menu/card.vue
@@ -1,29 +1,29 @@
 <template>
-  <div class="bg-white rounded-2xl overflow-hidden border border-slate-100 shadow-soft flex flex-col">
+  <div class="bg-white rounded-2xl overflow-hidden border border-slate-100 shadow-soft flex flex-col dark:bg-slate-950 dark:border-slate-800">
     <img :src="img" :alt="name" class="h-44 w-full object-cover">
     <div class="p-4 flex-1 flex flex-col">
       <div class="flex items-start justify-between gap-3">
         <div>
-          <h4 class="font-semibold text-lg">{{ name }}</h4>
-          <div class="text-sm text-slate-500">{{ category }}</div>
+          <h4 class="font-semibold text-lg text-slate-900 dark:text-slate-100">{{ name }}</h4>
+          <div class="text-sm text-slate-500 dark:text-slate-400">{{ category }}</div>
         </div>
         <div class="text-right">
-          <div class="font-bold text-brand-700">{{ fmt(price) }}</div>
+          <div class="font-bold text-brand-700 dark:text-brand-300">{{ fmt(price) }}</div>
           <div v-for="tag in tags" :key="tag" class='mt-1 flex flex-wrap gap-1'>
-            <span class="text-[11px] px-2 py-0.5 rounded-full bg-slate-100">{{ tag }}</span>
+            <span class="text-[11px] px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 dark:text-slate-200">{{ tag }}</span>
           </div>
         </div>
       </div>
       <div class="mt-3 flex items-center gap-2">
-        <button 
+        <button
           v-if="options"
-          class="px-3 py-2 text-sm rounded-xl border border-slate-200 hover:bg-slate-50" 
+          class="px-3 py-2 text-sm rounded-xl border border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
           @click="$emit('open-options', { id, name, category, price, tags, img, options })"
         >
           Выбрать
         </button>
-        <button 
-          class="px-3 py-2 text-sm rounded-xl bg-brand-600 text-white hover:bg-brand-700" 
+        <button
+          class="px-3 py-2 text-sm rounded-xl bg-brand-600 text-white hover:bg-brand-700"
           @click="$emit('add-to-cart', id)"
         >
           В корзину


### PR DESCRIPTION
## Summary
- extend dark mode styling to the header, footer, hero, controls, and menu cards
- align cart drawer, quick order dialog, and options dialog with the existing dark palette
- adjust the global app wrapper gradient to blend correctly in dark mode

## Testing
- npm run dev -- --host 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68e67617fcc88330af220c6921471692