### PR TITLE
Adjust hover styling for active category buttons

### DIFF
--- a/app/components/home/Content.vue
+++ b/app/components/home/Content.vue
@@ -45,10 +45,11 @@
         <button
           v-for="category in categories"
           :key="category"
-          class="px-3 py-1.5 rounded-full text-sm border border-slate-200 hover:bg-slate-50 whitespace-nowrap dark:text-slate-300 dark:border-slate-700 dark:hover:bg-slate-800"
-          :class="{
-            'bg-brand-600 text-white border-brand-600 dark:border-brand-500': selectedCategory === category,
-          }"
+          class="px-3 py-1.5 rounded-full text-sm border whitespace-nowrap transition-colors"
+          :class="selectedCategory === category
+            ? 'bg-brand-600 text-white border-brand-600 dark:border-brand-500'
+            : 'border-slate-200 text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:border-slate-700 dark:hover:bg-slate-800'
+          "
           @click="selectCategory(category)"
         >
           {{ category }}


### PR DESCRIPTION
## Summary
- stop applying hover background styles to the selected category button so it always retains the accent color
- keep hover feedback on inactive category buttons while preserving their default styling

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e69102728883309f7e405f40006795