### PR TITLE
Fix mobile dialogs covering the full viewport

### DIFF
--- a/app/components/cart/QuickOrder.vue
+++ b/app/components/cart/QuickOrder.vue
@@ -1,11 +1,13 @@
 <template>
   <div
     id="quickOrder"
-    class="fixed inset-0 items-end md:items-center justify-center z-50"
-    :class="{ hidden: !isOpen || !hasItems, flex: isOpen && hasItems }"
+    class="fixed inset-0 z-50 flex min-h-[100dvh] flex-col items-stretch justify-end md:items-center md:justify-center"
+    :class="{ hidden: !isOpen || !hasItems }"
   >
     <div class="absolute inset-0 bg-black/50" @click="close"></div>
-    <div class="w-full md:w-[720px] bg-white rounded-t-2xl md:rounded-2xl p-5 max-h-[90vh] overflow-y-auto shadow-soft z-50 dark:bg-slate-950 dark:text-slate-100">
+    <div
+      class="relative z-10 flex h-[100dvh] w-full flex-col overflow-y-auto rounded-none bg-white p-5 shadow-soft dark:bg-slate-950 dark:text-slate-100 md:h-auto md:max-h-[90vh] md:w-[720px] md:rounded-2xl"
+    >
       <div class="flex items-start justify-between gap-4">
         <h3 class="text-xl font-semibold text-slate-900 dark:text-slate-100">Оформление заказа</h3>
         <button class="text-slate-500 dark:text-slate-400" @click="close">✕</button>

--- a/app/components/dialog/options.vue
+++ b/app/components/dialog/options.vue
@@ -1,7 +1,12 @@
 <template>
-  <div v-if="isVisible" class="fixed inset-0 z-50 flex items-center justify-center">
+  <div
+    v-if="isVisible"
+    class="fixed inset-0 z-50 flex min-h-[100dvh] items-stretch justify-center p-4 sm:items-center"
+  >
     <div class="absolute inset-0 bg-black/50" @click="close"></div>
-    <div class="relative bg-white w-[92vw] max-w-md rounded-2xl p-5 shadow-soft dark:bg-slate-950 dark:text-slate-100">
+    <div
+      class="relative flex w-full max-w-md flex-col overflow-y-auto rounded-none bg-white p-5 shadow-soft dark:bg-slate-950 dark:text-slate-100 sm:max-h-[90vh] sm:rounded-3xl"
+    >
       <div class="flex items-start justify-between">
         <div class="font-semibold text-lg text-slate-900 dark:text-slate-100">{{ item.name }}</div>
         <button class="text-slate-500 dark:text-slate-400" @click="close">✕</button>


### PR DESCRIPTION
## Summary
- make the cart quick order modal stretch to the full mobile viewport height
- update the menu item options dialog to cover the mobile viewport while remaining scrollable

## Testing
- npm run dev -- --port 3000 --host 0.0.0.0

------
https://chatgpt.com/codex/tasks/task_e_68e69546dddc83308bfbc8c544d6862e